### PR TITLE
Customize inspect log to improve debugging experience

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,13 @@
+{
+    "cSpell.words": [
+        "github",
+        "hexutil",
+        "isatty",
+        "Ligneul",
+        "lmittmann",
+        "mattn",
+        "rollmelette",
+        "rollup",
+        "Rollup"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -427,7 +427,7 @@ The table below describes those examples.
 
 [NoNodo]: https://github.com/Calindra/nonodo
 [Cartesi-CLI]: https://docs.cartesi.io/
-[template]: https://github.com/gligneul/rollmelette-template
+[template]: https://github.com/rollmelette/rollmelette-template
 [solabi]: https://docs.soliditylang.org/en/latest/abi-spec.html
 [go-ethereum]: https://geth.ethereum.org/docs/developers/dapp-developer/native
 
@@ -447,3 +447,23 @@ The table below describes those examples.
 [roll.tester]: https://pkg.go.dev/github.com/rollmelette/rollmelette#Tester
 [roll.tester.inspect]: https://pkg.go.dev/github.com/rollmelette/rollmelette#Tester.Inspect
 [roll.tester.relayappaddress]: https://pkg.go.dev/github.com/rollmelette/rollmelette#Tester.RelayAppAddress
+
+## Log Level Configuration
+
+Control logging verbosity with the `ROLLMELETTE_LOG_LEVEL` environment variable:
+
+- **-4**: Debug (Default)
+- **0**: Info
+- **4**: Warn
+- **8**: Error
+
+### Usage
+
+Set the log level before running your application:
+
+```bash
+export ROLLMELETTE_LOG_LEVEL=4
+./your-application
+```
+
+Without setting this variable, the default is `Debug`.

--- a/rollmelette.go
+++ b/rollmelette.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"math/big"
 	"os"
+	"strconv"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/lmittmann/tint"
@@ -46,7 +47,7 @@ type Application interface {
 	Inspect(env EnvInspector, payload []byte) error
 }
 
-// EnvIspector is the entrypoint for the inspect functions of the Rollup API.
+// EnvInspector is the entrypoint for the inspect functions of the Rollup API.
 type EnvInspector interface {
 
 	// Report sends a report.
@@ -106,13 +107,20 @@ type Env interface {
 // init configures the slog package with the tint handler.
 func init() {
 	logOpts := new(tint.Options)
+
 	logOpts.Level = slog.LevelDebug
+	logLevelStr := os.Getenv("ROLLMELETTE_LOG_LEVEL")
+	if logLevelStr != "" {
+		if logLevel, err := strconv.Atoi(logLevelStr); err == nil {
+			logOpts.Level = slog.Level(logLevel)
+		}
+	}
 	logOpts.NoColor = !isatty.IsTerminal(os.Stdout.Fd())
 	// disable timestamp because it is irrelevant in the cartesi machine
 	logOpts.ReplaceAttr = func(groups []string, attr slog.Attr) slog.Attr {
 		if attr.Key == slog.TimeKey {
-			var zeroattr slog.Attr
-			return zeroattr
+			var zeroAttr slog.Attr
+			return zeroAttr
 		}
 		return attr
 	}


### PR DESCRIPTION
A developer asked for:

> By the way, maybe you guys could help me with something, while building the game utilizing the rollmelette, I wonder if there is a way to customize the inspect function output, that would help me, since the function prints the payload on the terminal every time  I call the advance function and since the the payload is kind of big it fills my terminal making my life harder when debugging and testing the the code
